### PR TITLE
Add configurable commands

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -44,7 +44,7 @@ repositories {
     }
 
     maven {
-        url = uri('https://hub.jeff-media.com/nexus/repository/jeff-media-public/')
+        url = uri('https://repo.jeff-media.com/public/')
     }
 
     maven {

--- a/src/main/java/me/truemb/discordnotify/database/VerifySQL.java
+++ b/src/main/java/me/truemb/discordnotify/database/VerifySQL.java
@@ -87,19 +87,28 @@ public class VerifySQL {
 					//REQUESTING
 					instance.getVerifyManager().setVerficationProgress(mcuuid, member.getIdLong());
 			    	cmd.reply(discordManager.getDiscordMessage("verification.request", placeholder));
+
+					final List<String> verifyCommandAliases = instance.getConfigManager().getConfig().getStringList("Options.CommandOverride.Minecraft.verify");
+					String verifyCommandName;
+					if(verifyCommandAliases != null && !verifyCommandAliases.isEmpty()) {
+						verifyCommandName = verifyCommandAliases.get(0);
+					} else {
+						verifyCommandName = "verify";
+					}
+					verifyCommandName = "/" + verifyCommandName;
 			    	
 			    	//MINECRAFT CLICK MESSAGE
 			    	TextComponent textComponent = Component
 			    			.text(instance.getConfigManager().getMinecraftMessage("verification.requestClickMessage.message", false).replaceAll("(?i)%user%", member.getUser().getAsTag()) + "\n")
 			    				.append(
 			    					Component.text(instance.getConfigManager().getMinecraftMessage("verification.requestClickMessage.accept", false))
-			    					.clickEvent(ClickEvent.runCommand("/verify accept"))
+			    					.clickEvent(ClickEvent.runCommand(verifyCommandName + " accept"))
 			    					.hoverEvent(HoverEvent.showText(Component.text(instance.getConfigManager().getMinecraftMessage("verification.requestClickMessage.acceptHover", false))))
 			    				).append(
 					    			Component.text(instance.getConfigManager().getMinecraftMessage("verification.requestClickMessage.space", false))
 					    		).append(
 				    				Component.text(instance.getConfigManager().getMinecraftMessage("verification.requestClickMessage.deny", false))
-				    				.clickEvent(ClickEvent.runCommand("/verify deny"))
+				    				.clickEvent(ClickEvent.runCommand(verifyCommandName + " deny"))
 				    				.hoverEvent(HoverEvent.showText(Component.text(instance.getConfigManager().getMinecraftMessage("verification.requestClickMessage.denyHover", false))))
 				    			);
 			    	

--- a/src/main/java/me/truemb/discordnotify/discord/commands/DC_PlayerInfoCommand.java
+++ b/src/main/java/me/truemb/discordnotify/discord/commands/DC_PlayerInfoCommand.java
@@ -27,8 +27,8 @@ public class DC_PlayerInfoCommand extends SimpleAddon {
 
 	private DiscordNotifyMain instance;
 	
-    public DC_PlayerInfoCommand(DiscordNotifyMain plugin) {
-        super("Disnotify PlayerInfo", "disnotify::playerinfo", plugin.getPluginDescription().getAuthor(), plugin.getPluginDescription().getVersion(), new String[] { "playerinfo", "pi" });
+    public DC_PlayerInfoCommand(DiscordNotifyMain plugin, String... aliases) {
+        super("Disnotify PlayerInfo", "disnotify::playerinfo", plugin.getPluginDescription().getAuthor(), plugin.getPluginDescription().getVersion(), aliases);
         this.instance = plugin;
     }
     

--- a/src/main/java/me/truemb/discordnotify/discord/commands/DC_VerifyCommand.java
+++ b/src/main/java/me/truemb/discordnotify/discord/commands/DC_VerifyCommand.java
@@ -22,8 +22,8 @@ public class DC_VerifyCommand extends SimpleAddon {
 	
 	private DiscordNotifyMain instance;
 	
-    public DC_VerifyCommand(DiscordNotifyMain plugin) {
-        super("Disnotify Verify", "disnotify::verify", plugin.getPluginDescription().getAuthor(), plugin.getPluginDescription().getVersion(), new String[] { "verify" });
+    public DC_VerifyCommand(DiscordNotifyMain plugin, String... aliases) {
+        super("Disnotify Verify", "disnotify::verify", plugin.getPluginDescription().getAuthor(), plugin.getPluginDescription().getVersion(), aliases);
         this.instance = plugin;
     }
     

--- a/src/main/java/me/truemb/discordnotify/utils/DiscordManager.java
+++ b/src/main/java/me/truemb/discordnotify/utils/DiscordManager.java
@@ -17,6 +17,7 @@ import java.util.regex.Pattern;
 
 import javax.annotation.Nullable;
 
+import com.google.common.collect.ImmutableList;
 import org.spicord.Spicord;
 import org.spicord.SpicordLoader;
 import org.spicord.bot.DiscordBot;
@@ -77,8 +78,18 @@ public class DiscordManager {
 	public void registerAddons(String botname) {
     	
     	//ADDONS NEEDS TO BE SET UP IN SPICORD
-	    this.playerInfoAddon = new DC_PlayerInfoCommand(this.instance);
-	    this.verifyAddon = new DC_VerifyCommand(this.instance);
+		List<String> playerInfoAliases = this.instance.getConfigManager().getConfig().getStringList("Options.CommandOverride.Discord.playerinfo");
+		if(playerInfoAliases == null || playerInfoAliases.isEmpty()){
+			playerInfoAliases = ImmutableList.of("pi", "playerinfo");
+		}
+
+		List<String> verifyAliases = this.instance.getConfigManager().getConfig().getStringList("Options.CommandOverride.Discord.verify");
+		if(verifyAliases == null || verifyAliases.isEmpty()){
+			verifyAliases = ImmutableList.of("verify");
+		}
+
+		this.playerInfoAddon = new DC_PlayerInfoCommand(this.instance, playerInfoAliases.toArray(new String[0]));
+		this.verifyAddon = new DC_VerifyCommand(this.instance, verifyAliases.toArray(new String[0]));
 	    	
 	    SpicordLoader.addStartupListener(spicord -> {
 	    	

--- a/src/main/java/me/truemb/universal/minecraft/commands/BukkitCommandExecutor_DChat.java
+++ b/src/main/java/me/truemb/universal/minecraft/commands/BukkitCommandExecutor_DChat.java
@@ -14,8 +14,8 @@ public class BukkitCommandExecutor_DChat extends BukkitCommand {
 	private DiscordNotifyMain instance;
 	private DN_DChatCommand dchatCommand;
 
-	public BukkitCommandExecutor_DChat(DiscordNotifyMain plugin) {
-		super("dchat");
+	public BukkitCommandExecutor_DChat(DiscordNotifyMain plugin, String name) {
+		super(name);
 		this.instance = plugin;
 		this.dchatCommand = new DN_DChatCommand(plugin);
 	}

--- a/src/main/java/me/truemb/universal/minecraft/commands/BukkitCommandExecutor_Staff.java
+++ b/src/main/java/me/truemb/universal/minecraft/commands/BukkitCommandExecutor_Staff.java
@@ -15,8 +15,8 @@ public class BukkitCommandExecutor_Staff extends BukkitCommand {
 	private DiscordNotifyMain instance;
 	private DN_StaffCommand staffCommand;
 
-	public BukkitCommandExecutor_Staff(DiscordNotifyMain plugin) {
-		super("staff", null, null, Arrays.asList("Options.Broadcast"));
+	public BukkitCommandExecutor_Staff(DiscordNotifyMain plugin, String name) {
+		super(name);
 		this.instance = plugin;
 		this.staffCommand = new DN_StaffCommand(plugin);
 	}

--- a/src/main/java/me/truemb/universal/minecraft/commands/BukkitCommandExecutor_Verify.java
+++ b/src/main/java/me/truemb/universal/minecraft/commands/BukkitCommandExecutor_Verify.java
@@ -16,8 +16,8 @@ public class BukkitCommandExecutor_Verify extends BukkitCommand {
 	private DiscordNotifyMain instance;
 	private DN_VerifyCommand verifyCommand;
 
-	public BukkitCommandExecutor_Verify(DiscordNotifyMain plugin) {
-		super("verify");
+	public BukkitCommandExecutor_Verify(DiscordNotifyMain plugin, String name) {
+		super(name);
 		this.instance = plugin;
 		this.verifyCommand = new DN_VerifyCommand(plugin);
 	}

--- a/src/main/java/me/truemb/universal/minecraft/commands/BungeeCommandExecutor_DChat.java
+++ b/src/main/java/me/truemb/universal/minecraft/commands/BungeeCommandExecutor_DChat.java
@@ -14,8 +14,8 @@ public class BungeeCommandExecutor_DChat extends Command {
 	private DiscordNotifyMain instance;
 	private DN_DChatCommand dchatCommand;
 
-	public BungeeCommandExecutor_DChat(DiscordNotifyMain plugin) {
-		super("dchat");
+	public BungeeCommandExecutor_DChat(DiscordNotifyMain plugin, String name, String... aliases) {
+		super(name, null, aliases);
 		this.instance = plugin;
 		this.dchatCommand = new DN_DChatCommand(plugin);
 	}

--- a/src/main/java/me/truemb/universal/minecraft/commands/BungeeCommandExecutor_Staff.java
+++ b/src/main/java/me/truemb/universal/minecraft/commands/BungeeCommandExecutor_Staff.java
@@ -14,8 +14,8 @@ public class BungeeCommandExecutor_Staff extends Command {
 	private DiscordNotifyMain instance;
 	private DN_StaffCommand staffCommand;
 
-	public BungeeCommandExecutor_Staff(DiscordNotifyMain plugin) {
-		super("staff", plugin.getConfigManager().getConfig().getString("Permissions.StaffChat"), "s");
+	public BungeeCommandExecutor_Staff(DiscordNotifyMain plugin, String name, String... aliases) {
+		super(name, plugin.getConfigManager().getConfig().getString("Permissions.StaffChat"), aliases);
 		this.instance = plugin;
 		this.staffCommand = new DN_StaffCommand(plugin);
 	}

--- a/src/main/java/me/truemb/universal/minecraft/commands/BungeeCommandExecutor_Verify.java
+++ b/src/main/java/me/truemb/universal/minecraft/commands/BungeeCommandExecutor_Verify.java
@@ -17,8 +17,8 @@ public class BungeeCommandExecutor_Verify extends Command implements TabExecutor
 	private DiscordNotifyMain instance;
 	private DN_VerifyCommand verifyCommand;
 
-	public BungeeCommandExecutor_Verify(DiscordNotifyMain plugin) {
-		super("verify");
+	public BungeeCommandExecutor_Verify(DiscordNotifyMain plugin, String name, String... aliases) {
+		super(name, null, aliases);
 		this.instance = plugin;
 		this.verifyCommand = new DN_VerifyCommand(plugin);
 	}

--- a/src/main/java/me/truemb/universal/minecraft/main/BukkitMain.java
+++ b/src/main/java/me/truemb/universal/minecraft/main/BukkitMain.java
@@ -5,6 +5,7 @@ import java.util.ArrayList;
 import java.util.Collection;
 import java.util.List;
 
+import com.google.common.collect.ImmutableList;
 import org.bstats.bukkit.Metrics;
 import org.bukkit.Bukkit;
 import org.bukkit.command.CommandMap;
@@ -73,18 +74,49 @@ public class BukkitMain extends JavaPlugin implements IRelay {
 			    commandMapField.setAccessible(true);
 			    CommandMap commandMap = (CommandMap) commandMapField.get(Bukkit.getServer());
 
-				BukkitCommandExecutor_Staff staffCommand = new BukkitCommandExecutor_Staff(this.instance);
-				commandMap.register("staff", staffCommand);
-				List<String> staffAliases = new ArrayList<>();
-				staffAliases.add("s");
-				staffCommand.setAliases(staffAliases);
-			    
-				BukkitCommandExecutor_Verify verifyCommand = new BukkitCommandExecutor_Verify(this.instance);
-				commandMap.register("verify", verifyCommand);
-				
+				// STAFF COMMAND
+				final List<String> staffCommandAliases = this.instance.getConfigManager().getConfig().getStringList("Options.CommandOverride.staff");
+
+				BukkitCommandExecutor_Staff staffCommand;
+				if(staffCommandAliases != null && !staffCommandAliases.isEmpty()) {
+					final String commandName = staffCommandAliases.remove(0);
+					staffCommand = new BukkitCommandExecutor_Staff(this.instance, commandName);
+					commandMap.register(commandName, staffCommand);
+					staffCommand.setAliases(staffCommandAliases);
+				} else{
+					staffCommand = new BukkitCommandExecutor_Staff(this.instance, "staff");
+					commandMap.register("staff", staffCommand);
+					staffCommand.setAliases(ImmutableList.of("s"));
+				}
+
+				// VERIFY COMMAND
+				final List<String> verifyCommandAliases = this.instance.getConfigManager().getConfig().getStringList("Options.CommandOverride.verify");
+
+				BukkitCommandExecutor_Verify verifyCommand;
+				if(verifyCommandAliases != null && !verifyCommandAliases.isEmpty()) {
+					final String commandName = verifyCommandAliases.remove(0);
+					verifyCommand = new BukkitCommandExecutor_Verify(this.instance, commandName);
+					commandMap.register(commandName, verifyCommand);
+					verifyCommand.setAliases(verifyCommandAliases);
+				} else {
+					verifyCommand = new BukkitCommandExecutor_Verify(this.instance, "verify");
+					commandMap.register("verify", verifyCommand);
+				}
+
+				// DCHAT COMMAND
 				if(this.instance.getConfigManager().getConfig().getBoolean("Options.Chat.enableSplittedChat")) {
-					BukkitCommandExecutor_DChat dchatCommand = new BukkitCommandExecutor_DChat(this.instance);
-					commandMap.register("dchat", dchatCommand);
+					final List<String> dchatCommandAliases = this.instance.getConfigManager().getConfig().getStringList("Options.CommandOverride.Minecraft.dchat");
+
+					BukkitCommandExecutor_DChat dchatCommand;
+					if (dchatCommandAliases != null && !dchatCommandAliases.isEmpty()) {
+						final String commandName = dchatCommandAliases.remove(0);
+						dchatCommand = new BukkitCommandExecutor_DChat(this.instance, commandName);
+						commandMap.register(commandName, dchatCommand);
+						dchatCommand.setAliases(dchatCommandAliases);
+					} else {
+						dchatCommand = new BukkitCommandExecutor_DChat(this.instance, "dchat");
+						commandMap.register("dchat", dchatCommand);
+					}
 				}
 			    
 			}catch(Exception exception){

--- a/src/main/java/me/truemb/universal/minecraft/main/BungeeMain.java
+++ b/src/main/java/me/truemb/universal/minecraft/main/BungeeMain.java
@@ -4,6 +4,7 @@ import java.net.SocketAddress;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.HashMap;
+import java.util.List;
 
 import org.bstats.bungeecord.Metrics;
 
@@ -75,16 +76,43 @@ public class BungeeMain extends Plugin implements IRelay, Listener {
 		
 		//LOAD COMMANDS
 		if(this.instance.getConfigManager().getConfig().getBoolean("Options.Chat.enableSplittedChat")) {
-			BungeeCommandExecutor_DChat dchatCommand = new BungeeCommandExecutor_DChat(this.instance);
+			final List<String> commandAliases = this.instance.getConfigManager().getConfig().getStringList("Options.CommandOverride.Minecraft.dchat");
+			BungeeCommandExecutor_DChat dchatCommand;
+
+			if(commandAliases != null && !commandAliases.isEmpty()) {
+				final String commandName = commandAliases.remove(0);
+				dchatCommand = new BungeeCommandExecutor_DChat(this.instance, commandName, commandAliases.toArray(new String[0]));
+			}else {
+				dchatCommand = new BungeeCommandExecutor_DChat(this.instance, "dchat");
+			}
+
 			ProxyServer.getInstance().getPluginManager().registerCommand(this, dchatCommand);
 		}
 		
 		if(this.instance.getConfigManager().isFeatureEnabled(FeatureType.Staff)) {
-			BungeeCommandExecutor_Staff staffCommand = new BungeeCommandExecutor_Staff(this.instance);
+			final List<String> commandAliases = this.instance.getConfigManager().getConfig().getStringList("Options.CommandOverride.staff");
+ 			BungeeCommandExecutor_Staff staffCommand;
+
+			 if(commandAliases != null && !commandAliases.isEmpty()) {
+				 final String commandName = commandAliases.remove(0);
+			 	staffCommand = new BungeeCommandExecutor_Staff(this.instance, commandName, commandAliases.toArray(new String[0]));
+			 }else{
+				 staffCommand = new BungeeCommandExecutor_Staff(this.instance, "staff", "s");
+			 }
+
 			ProxyServer.getInstance().getPluginManager().registerCommand(this, staffCommand);
 		}
+
+		List<String> verifyCommandAliases = this.instance.getConfigManager().getConfig().getStringList("Options.CommandOverride.verify");
+		BungeeCommandExecutor_Verify verifyCommand;
+
+		if(verifyCommandAliases != null && !verifyCommandAliases.isEmpty()) {
+			final String commandName = verifyCommandAliases.remove(0);
+			verifyCommand = new BungeeCommandExecutor_Verify(this.instance, commandName, verifyCommandAliases.toArray(new String[0]));
+		}else{
+			verifyCommand = new BungeeCommandExecutor_Verify(this.instance, "verify");
+		}
 		
-		BungeeCommandExecutor_Verify verifyCommand = new BungeeCommandExecutor_Verify(this.instance);
 		ProxyServer.getInstance().getPluginManager().registerCommand(this, verifyCommand);
 		
 		//METRICS ANALYTICS

--- a/src/main/java/me/truemb/universal/minecraft/main/SpongeMain.java
+++ b/src/main/java/me/truemb/universal/minecraft/main/SpongeMain.java
@@ -3,7 +3,9 @@ package me.truemb.universal.minecraft.main;
 import java.nio.file.Path;
 import java.util.ArrayList;
 import java.util.Collection;
+import java.util.List;
 
+import me.truemb.discordnotify.utils.UTF8YamlConfiguration;
 import org.spongepowered.api.Game;
 import org.spongepowered.api.ResourceKey;
 import org.spongepowered.api.command.Command;
@@ -111,9 +113,13 @@ public class SpongeMain implements IRelay {
     	
 		//LOAD COMMANDS
 		if(!this.instance.getUniversalServer().isProxySubServer()) {
-	    	e.register(this.pluginContainer, this.dchatCommand, "dchat");
-	    	e.register(this.pluginContainer, this.verifyCommand, "verify");
-	    	e.register(this.pluginContainer, this.staffCommand, "staff", "s");
+            registerCommand(e, "dchat", this.dchatCommand, "dchat");
+
+            // verify -
+            registerCommand(e, "verify", this.verifyCommand, "verify");
+
+            // staff -
+            registerCommand(e, "staff", this.staffCommand, "staff");
 		}
     }
 
@@ -168,4 +174,15 @@ public class SpongeMain implements IRelay {
         return false;
     }
 
+    private void registerCommand(RegisterCommandEvent<Command.Raw> e, String configName, Command.Raw command, String fallbackName) {
+        final UTF8YamlConfiguration config = this.instance.getConfigManager().getConfig();
+        final List<String> commandAliases = config.getStringList("Options.CommandOverride.Minecraft." + configName);
+        if (commandAliases != null && !commandAliases.isEmpty()) {
+            final String first = commandAliases.get(0);
+            commandAliases.remove(0);
+            e.register(this.pluginContainer, command, first, commandAliases.toArray(new String[0]));
+        } else {
+            e.register(this.pluginContainer, command, fallbackName);
+        }
+    }
 }

--- a/src/main/resources/config.yml
+++ b/src/main/resources/config.yml
@@ -166,6 +166,15 @@ Options:
     serverSeperatedStatus:
       lobby: -1
       freebuild: -1
+  CommandOverride:
+    Discord:
+      playerinfo: [ "playerinfo", "pi" ]
+      verify: [ "verify" ]
+    Minecraft:
+      verify: ["verify"]
+      staff: ["staff", "s"]
+      dchat: ["dchat"]
+
 #Add the discord Groups in the Lists. If there is a group set, it wont be public for everybody anymore.
 DiscordCommandAllowedGroups:
   Verify:


### PR DESCRIPTION
Allow for the Minecraft and Discord commands to be configured, to avoid conflicting naming.

New Config Location `Options.CommandOverride`
```
  CommandOverride:
    Discord:
      playerinfo: [ "playerinfo", "pi" ]
      verify: [ "verify" ]
    Minecraft:
      verify: ["verify"]
      staff: ["staff", "s"]
      dchat: ["dchat"]
```

First value in the config is the Default Command name, the rest are consider aliases